### PR TITLE
#ENVELOPEDEV41 Таски: ответы на RabbitMq

### DIFF
--- a/envelope-backend/docker-compose.yml
+++ b/envelope-backend/docker-compose.yml
@@ -121,6 +121,8 @@ services:
     environment:
       - RABBITMQ_DEFAULT_USER=admin
       - RABBITMQ_DEFAULT_PASS=admin
+    networks:
+      - services_network
     ports:
       - "15672:15672"
       - "5672:5672"

--- a/envelope-backend/src/infrastructure/Envelope.Common/Enums/Difficult.cs
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Enums/Difficult.cs
@@ -1,4 +1,4 @@
-﻿namespace TaskService.Domain.Enums;
+﻿namespace Envelope.Common.Enums;
 
 /// <summary>
 /// Сложность задачи

--- a/envelope-backend/src/infrastructure/Envelope.Common/Enums/TaskGlobalState.cs
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Enums/TaskGlobalState.cs
@@ -1,4 +1,4 @@
-﻿namespace TaskService.Domain.Enums;
+﻿namespace Envelope.Common.Enums;
 
 /// <summary>
 /// Состояние задачи 

--- a/envelope-backend/src/infrastructure/Envelope.Common/Envelope.Common.csproj
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Envelope.Common.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Folder Include="Messages\" />
+      <Folder Include="Messages\EventMessages\" />
     </ItemGroup>
 
 </Project>

--- a/envelope-backend/src/infrastructure/Envelope.Common/Messages/RequestMessages/Tasks/GetTaskByIdRequestMessage.cs
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Messages/RequestMessages/Tasks/GetTaskByIdRequestMessage.cs
@@ -1,0 +1,12 @@
+﻿namespace Envelope.Common.Messages.RequestMessages.Tasks;
+
+/// <summary>
+/// Сообщение-запрос на получение информации об таске по Id
+/// </summary>
+public class GetTaskByIdRequestMessage
+{
+    /// <summary>
+    /// Id задачи.
+    /// </summary>
+    public Guid Id { get; set; }
+}

--- a/envelope-backend/src/infrastructure/Envelope.Common/Messages/ResponseMessages/Tasks/TaskResponseMessage.cs
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Messages/ResponseMessages/Tasks/TaskResponseMessage.cs
@@ -1,14 +1,14 @@
 ﻿using Envelope.Common.Enums;
 
-namespace TaskService.Domain.Projections;
+namespace Envelope.Common.Messages.ResponseMessages.Tasks;
 
-public class GlobalTaskProjection
+public class TaskResponseMessage
 {
     /// <summary>
-    /// Суррогатный ключ
+    /// Id задачи
     /// </summary>
     public Guid Id { get; set; }
-
+    
     /// <summary>
     /// Название
     /// </summary>

--- a/envelope-backend/src/infrastructure/Envelope.Common/Queries/QueueNames.cs
+++ b/envelope-backend/src/infrastructure/Envelope.Common/Queries/QueueNames.cs
@@ -1,0 +1,12 @@
+﻿namespace Envelope.Common.Queries;
+
+/// <summary>
+/// Класс с константами названий очередей
+/// </summary>
+public class QueueNames
+{
+    /// <summary>
+    /// Очередь на получение информации о задачах
+    /// </summary>
+    public const string GetTaskQueue = "GET_TASK_QUERY";
+}

--- a/envelope-backend/src/services/TaskService/TaskService.API/Controllers/TaskProjectionController.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.API/Controllers/TaskProjectionController.cs
@@ -62,7 +62,7 @@ public class TaskProjectionController : ControllerBase
         [FromRoute] Guid authorId,
         CancellationToken cancellationToken)
     {
-        var result = await _mediator.Send(new GetTaskProjectionQuery { TaskId = id, AuthorId = authorId}, cancellationToken);
+        var result = await _mediator.Send(new GetTaskProjectionQuery { TaskId = id }, cancellationToken);
 
         if (result.IsSuccess)
         {

--- a/envelope-backend/src/services/TaskService/TaskService.API/appsettings.json
+++ b/envelope-backend/src/services/TaskService/TaskService.API/appsettings.json
@@ -9,5 +9,11 @@
     "TaskEventStore": "Host=localhost;Port=5432;Database=taskEventStore;Username=postgres;Password=123",
     "TaskProjectionDatabase": "Host=localhost;Port=5432;Database=taskProjectionDb;Username=postgres;Password=123"
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "RabbitMqOptions": {
+    "Hostname": "localhost",
+    "Port": "5672",
+    "Login": "admin",
+    "Password": "admin"
+  }
 }

--- a/envelope-backend/src/services/TaskService/TaskService.Application/BackgroundServices/Interfaces/ITaskBackgroundService.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/BackgroundServices/Interfaces/ITaskBackgroundService.cs
@@ -1,0 +1,17 @@
+﻿using Envelope.Common.Messages.RequestMessages.Tasks;
+using Envelope.Common.Messages.ResponseMessages.Tasks;
+
+namespace TaskService.Application.BackgroundServices.Interfaces;
+
+/// <summary>
+/// Background сервис задач
+/// </summary>
+public interface ITaskBackgroundService
+{
+    /// <summary>
+    /// Получить ответ на запрос получения задачи по Id
+    /// </summary>
+    /// <param name="message">Сообщение-запрос на получение</param>
+    /// <returns>Сообщение-ответ с информацией</returns>
+    Task<TaskResponseMessage> ResponseAsync(GetTaskByIdRequestMessage message);
+}

--- a/envelope-backend/src/services/TaskService/TaskService.Application/BackgroundServices/TaskBackgroundService.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/BackgroundServices/TaskBackgroundService.cs
@@ -1,0 +1,53 @@
+﻿using Envelope.Common.Messages.RequestMessages.Tasks;
+using Envelope.Common.Messages.ResponseMessages.Tasks;
+using Envelope.Common.Queries;
+using Envelope.Integration.Interfaces;
+using Microsoft.Extensions.Hosting;
+using TaskService.Application.BackgroundServices.Interfaces;
+using TaskService.Application.Repositories.ReadOnlyRepositories;
+
+namespace TaskService.Application.BackgroundServices;
+
+public class TaskBackgroundService : BackgroundService, ITaskBackgroundService
+{
+    private readonly IMessageBus _messageBus;
+    private readonly ITaskProjectionReadOnlyRepository _repository;
+
+    public TaskBackgroundService(IMessageBus messageBus, ITaskProjectionReadOnlyRepository repository)
+    {
+        _messageBus = messageBus;
+        _repository = repository;
+    }
+
+    public async Task<TaskResponseMessage> ResponseAsync(GetTaskByIdRequestMessage message)
+    {
+        var task = await _repository.GetProjectionAsync(message.Id, CancellationToken.None);
+
+        if (task == default)
+        {
+            throw new KeyNotFoundException($"No projection with id {message.Id} was found.");
+        }
+
+        var response = new TaskResponseMessage
+        {
+            Id = task.Id,
+            Answer = task.Answer,
+            Author = task.Author,
+            CreationDate = task.CreationDate,
+            Description = task.Description,
+            Difficult = task.Difficult,
+            ExecutionTime = task.ExecutionTime,
+            Name = task.Name,
+            UpdateDate = task.UpdateDate,
+        };
+        
+        return response;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await _messageBus.SubscribeResponseAsync<GetTaskByIdRequestMessage, TaskResponseMessage>(
+            QueueNames.GetTaskQueue,
+            ResponseAsync);
+    }
+}

--- a/envelope-backend/src/services/TaskService/TaskService.Application/DependencyInjection.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/DependencyInjection.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using Envelope.Integration.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TaskService.Application.BackgroundServices;
 using TaskService.Application.EventBus.Interfaces;
 using TaskService.Application.Handlers.Commands.AddTask;
 
@@ -11,6 +13,8 @@ public static class DependencyInjection
     {
         AddMediator(services);
         AddEventBus(services);
+        AddMessageBus(services, configuration);
+        AddBackgroundServices(services);
         return services;
     }
 
@@ -25,4 +29,13 @@ public static class DependencyInjection
         services.AddScoped<IEventBus, EventBus.EventBus>();
     }
 
+    private static void AddMessageBus(IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddIntegrationMessageBus(configuration);
+    }
+
+    private static void AddBackgroundServices(IServiceCollection services)
+    {
+        services.AddHostedService<TaskBackgroundService>();
+    }
 }

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Commands/AddTask/AddTaskCommand.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Commands/AddTask/AddTaskCommand.cs
@@ -1,6 +1,6 @@
-﻿using Envelope.Common.ResultPattern;
+﻿using Envelope.Common.Enums;
+using Envelope.Common.ResultPattern;
 using MediatR;
-using TaskService.Domain.Enums;
 
 namespace TaskService.Application.Handlers.Commands.AddTask;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Commands/UpdateTask/UpdateTaskCommand.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Commands/UpdateTask/UpdateTaskCommand.cs
@@ -1,6 +1,6 @@
-﻿using MediatR;
+﻿using Envelope.Common.Enums;
+using MediatR;
 using Envelope.Common.ResultPattern;
-using TaskService.Domain.Enums;
 
 namespace TaskService.Application.Handlers.Commands.UpdateTask;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Queries/TaskProjectionProjection/GetTaskProjection/GetTaskProjectionQuery.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Queries/TaskProjectionProjection/GetTaskProjection/GetTaskProjectionQuery.cs
@@ -6,6 +6,5 @@ namespace TaskService.Application.Handlers.Queries.TaskProjectionProjection.GetT
 
 public class GetTaskProjectionQuery : IRequest<Result<GetTaskProjectionResponse>>
 {
-    public Guid AuthorId { get; set; }
     public Guid TaskId { get; set; }
 }

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Queries/TaskProjectionProjection/GetTaskProjection/GetTaskProjectionQueryHandler.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Handlers/Queries/TaskProjectionProjection/GetTaskProjection/GetTaskProjectionQueryHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Envelope.Common.Exceptions;
 using MediatR;
 using Envelope.Common.ResultPattern;
-using TaskService.Application.Exceptions;
 using TaskService.Application.Mapping.Responses;
 using TaskService.Application.Repositories.ReadOnlyRepositories;
 using TaskService.Application.Responses.TaskProjections.GetTaskProjection;
@@ -17,7 +16,7 @@ public class GetTaskProjectionQueryHandler : IRequestHandler<GetTaskProjectionQu
     
     public async Task<Result<GetTaskProjectionResponse>> Handle(GetTaskProjectionQuery request, CancellationToken cancellationToken)
     {
-        var projection = await _repository.GetProjectionAsync(request.AuthorId, request.TaskId, cancellationToken);
+        var projection = await _repository.GetProjectionAsync(request.TaskId, cancellationToken);
 
         if (projection is null)
         {

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Repositories/ReadOnlyRepositories/ITaskProjectionReadOnlyRepository.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Repositories/ReadOnlyRepositories/ITaskProjectionReadOnlyRepository.cs
@@ -4,6 +4,6 @@ namespace TaskService.Application.Repositories.ReadOnlyRepositories;
 
 public interface ITaskProjectionReadOnlyRepository
 {
-    Task<TaskProjection?> GetProjectionAsync(Guid authorId, Guid projectionId, CancellationToken cancellationToken);
+    Task<TaskProjection?> GetProjectionAsync(Guid projectionId, CancellationToken cancellationToken);
     Task<ICollection<TaskProjection>> GetProjectionsAsync(Guid authorId, CancellationToken cancellationToken);
 }

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/GlobalTaskProjections/GetAllGlobalProjections/GetAllGlobalProjectionsInfo.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/GlobalTaskProjections/GetAllGlobalProjections/GetAllGlobalProjectionsInfo.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.GlobalTaskProjections.GetAllGlobalProjections;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/GlobalTaskProjections/GetGlobalProjection/GetProjectionResponse.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/GlobalTaskProjections/GetGlobalProjection/GetProjectionResponse.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.GlobalTaskProjections.GetGlobalProjection;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/SentToCheckProjections/GetAllSentToCheckProjections/GetAllSentToCheckProjectionsInfo.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/SentToCheckProjections/GetAllSentToCheckProjections/GetAllSentToCheckProjectionsInfo.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.SentToCheckProjections.GetAllSentToCheckProjections;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/SentToCheckProjections/GetSentToCheckProjection/GetSentToCheckProjectionResponse.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/SentToCheckProjections/GetSentToCheckProjection/GetSentToCheckProjectionResponse.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.SentToCheckProjections.GetSentToCheckProjection;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/TaskProjections/GetAllTaskProjections/GetAllGlobalProjectionsInfo.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/TaskProjections/GetAllTaskProjections/GetAllGlobalProjectionsInfo.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.TaskProjections.GetAllTaskProjections;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/Responses/TaskProjections/GetTaskProjection/GetTaskProjectionResponse.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/Responses/TaskProjections/GetTaskProjection/GetTaskProjectionResponse.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Application.Responses.TaskProjections.GetTaskProjection;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Application/TaskService.Application.csproj
+++ b/envelope-backend/src/services/TaskService/TaskService.Application/TaskService.Application.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\infrastructure\Envelope.Common\Envelope.Common.csproj" />
+    <ProjectReference Include="..\..\..\infrastructure\Envelope.Integration\Envelope.Integration.csproj" />
     <ProjectReference Include="..\TaskService.Domain\TaskService.Domain.csproj" />
   </ItemGroup>
 
@@ -15,6 +16,7 @@
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
   </ItemGroup>
 
 </Project>

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/Aggregates/Task.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/Aggregates/Task.cs
@@ -1,5 +1,5 @@
 ﻿using System.Diagnostics;
-using TaskService.Domain.Enums;
+using Envelope.Common.Enums;
 using TaskService.Domain.Events;
 using TaskService.Domain.Events.Base;
 using TaskService.Domain.Interfaces;

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/Events/BaseTaskCreated.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/Events/BaseTaskCreated.cs
@@ -1,7 +1,6 @@
-﻿using MediatR;
-using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
+using MediatR;
 using TaskService.Domain.Events.Base;
-using TaskService.Domain.Interfaces;
 
 namespace TaskService.Domain.Events;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/Events/BaseTaskUpdated.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/Events/BaseTaskUpdated.cs
@@ -1,5 +1,5 @@
-﻿using MediatR;
-using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
+using MediatR;
 using TaskService.Domain.Events.Base;
 
 namespace TaskService.Domain.Events;

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/Projections/SentToCheckTaskProjection.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/Projections/SentToCheckTaskProjection.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Domain.Projections;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/Projections/TaskProjection.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/Projections/TaskProjection.cs
@@ -1,4 +1,4 @@
-﻿using TaskService.Domain.Enums;
+﻿using Envelope.Common.Enums;
 
 namespace TaskService.Domain.Projections;
 

--- a/envelope-backend/src/services/TaskService/TaskService.Domain/TaskService.Domain.csproj
+++ b/envelope-backend/src/services/TaskService/TaskService.Domain/TaskService.Domain.csproj
@@ -10,4 +10,8 @@
     <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\infrastructure\Envelope.Common\Envelope.Common.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/envelope-backend/src/services/TaskService/TaskService.Persistence/DependencyInjection.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Persistence/DependencyInjection.cs
@@ -70,9 +70,9 @@ public static class DependencyInjection
             .UseNpgsql(taskProjectionDatabaseConnectionString)
             .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking));
         
-        services.AddScoped<IGlobalProjectionReadOnlyRepository, EfGlobalProjectionReadOnlyRepository>();
-        services.AddScoped<ITaskProjectionReadOnlyRepository, EfTaskProjectionReadOnlyRepository>();
-        services.AddScoped<ISentToCheckProjectionReadOnlyRepository, EfSentToCheckProjectionReadOnlyRepository>();
+        services.AddSingleton<IGlobalProjectionReadOnlyRepository, EfGlobalProjectionReadOnlyRepository>();
+        services.AddSingleton<ITaskProjectionReadOnlyRepository, EfTaskProjectionReadOnlyRepository>();
+        services.AddSingleton<ISentToCheckProjectionReadOnlyRepository, EfSentToCheckProjectionReadOnlyRepository>();
     }
     
     /// <summary>

--- a/envelope-backend/src/services/TaskService/TaskService.Persistence/Repositories/ReadOnlyRepositories/EfTaskProjectionReadOnlyRepository.cs
+++ b/envelope-backend/src/services/TaskService/TaskService.Persistence/Repositories/ReadOnlyRepositories/EfTaskProjectionReadOnlyRepository.cs
@@ -12,8 +12,8 @@ public class EfTaskProjectionReadOnlyRepository : ITaskProjectionReadOnlyReposit
     public EfTaskProjectionReadOnlyRepository(TaskReadOnlyContext context) =>
         _context = context;
     
-    public async Task<TaskProjection?> GetProjectionAsync(Guid authorId, Guid projectionId, CancellationToken cancellationToken)  =>
-        await _context.TaskProjections.FirstOrDefaultAsync(p => p.Id == projectionId && p.Author == authorId, cancellationToken);
+    public async Task<TaskProjection?> GetProjectionAsync(Guid projectionId, CancellationToken cancellationToken)  =>
+        await _context.TaskProjections.FirstOrDefaultAsync(p => p.Id == projectionId, cancellationToken);
 
     public async Task<ICollection<TaskProjection>> GetProjectionsAsync(Guid authorId, CancellationToken cancellationToken) =>
         await _context.TaskProjections.ToListAsync(cancellationToken);

--- a/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/CommandHandlerTests/NegativeDefaultCommandHandlersTests.cs
+++ b/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/CommandHandlerTests/NegativeDefaultCommandHandlersTests.cs
@@ -1,4 +1,5 @@
-﻿using Envelope.Common.Exceptions;
+﻿using Envelope.Common.Enums;
+using Envelope.Common.Exceptions;
 using TaskService.Application.Exceptions;
 using TaskService.Application.Handlers.Commands.AddTask;
 using TaskService.Application.Handlers.Commands.RefuseTask;
@@ -6,7 +7,6 @@ using TaskService.Application.Handlers.Commands.RemoveTask;
 using TaskService.Application.Handlers.Commands.SentToCheckTask;
 using TaskService.Application.Handlers.Commands.SentToGlobalTask;
 using TaskService.Application.Handlers.Commands.UpdateTask;
-using TaskService.Domain.Enums;
 using TaskService.Tests.TaskServiceApplication.Tests.Infrastructure;
 
 namespace TaskService.Tests.TaskServiceApplication.Tests.CommandHandlerTests;

--- a/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/CommandHandlerTests/PositiveDefaultCommandHandlersTests.cs
+++ b/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/CommandHandlerTests/PositiveDefaultCommandHandlersTests.cs
@@ -1,4 +1,5 @@
-﻿using MediatR;
+﻿using Envelope.Common.Enums;
+using MediatR;
 using Envelope.Common.ResultPattern;
 using TaskService.Application.Handlers.Commands.AddTask;
 using TaskService.Application.Handlers.Commands.RefuseTask;
@@ -6,7 +7,6 @@ using TaskService.Application.Handlers.Commands.RemoveTask;
 using TaskService.Application.Handlers.Commands.SentToCheckTask;
 using TaskService.Application.Handlers.Commands.SentToGlobalTask;
 using TaskService.Application.Handlers.Commands.UpdateTask;
-using TaskService.Domain.Enums;
 using TaskService.Domain.Events;
 using TaskService.Tests.TaskServiceApplication.Tests.Infrastructure;
 

--- a/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/Infrastructure/Repositories/MockCommonTaskRepository.cs
+++ b/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/Infrastructure/Repositories/MockCommonTaskRepository.cs
@@ -78,8 +78,8 @@ public class MockCommonTaskRepository :
         }, cancellationToken);
 
 
-    public async Task<TaskProjection?> GetProjectionAsync(Guid authorId, Guid projectionId, CancellationToken cancellationToken)  =>
-        await Task.Run(() => _commonListStorage.TaskProjections.FirstOrDefault(p => p.Id == projectionId && p.Author == authorId), cancellationToken);
+    public async Task<TaskProjection?> GetProjectionAsync(Guid projectionId, CancellationToken cancellationToken)  =>
+        await Task.Run(() => _commonListStorage.TaskProjections.FirstOrDefault(p => p.Id == projectionId), cancellationToken);
 
     public async Task<ICollection<TaskProjection>> GetProjectionsAsync(Guid authorId,
         CancellationToken cancellationToken) =>

--- a/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/QueryAndNotificationHandlerTests/PositiveDefaultQueryAndNotificationGlobalHandlerTests.cs
+++ b/envelope-backend/tests/services/TaskService.Tests/TaskServiceApplication.Tests/QueryAndNotificationHandlerTests/PositiveDefaultQueryAndNotificationGlobalHandlerTests.cs
@@ -1,4 +1,5 @@
-﻿using TaskService.Application.Handlers.Commands.AddTask;
+﻿using Envelope.Common.Enums;
+using TaskService.Application.Handlers.Commands.AddTask;
 using TaskService.Application.Handlers.Commands.RemoveTask;
 using TaskService.Application.Handlers.Commands.SentToCheckTask;
 using TaskService.Application.Handlers.Commands.SentToGlobalTask;
@@ -8,7 +9,6 @@ using TaskService.Application.Handlers.Queries.SentToCheckProjectionQueryHandler
 using TaskService.Application.Handlers.Queries.SentToCheckProjectionQueryHandler.GetSentToCheckProjection;
 using TaskService.Application.Handlers.Queries.TaskProjectionProjection.GetAllTaskProjection;
 using TaskService.Application.Responses.GlobalTaskProjections.GetGlobalProjection;
-using TaskService.Domain.Enums;
 using TaskService.Tests.TaskServiceApplication.Tests.Infrastructure;
 
 namespace TaskService.Tests.TaskServiceApplication.Tests.QueryAndNotificationHandlerTests;


### PR DESCRIPTION
- enum перенесены в библиотеку common (по моему мнению именнованные константы имеют права обобщаться для всего контекста, а не в контексте одного сервиса)
- изменены readOnlyRepository на singleton (факт - readOnlyRepository не имеют трэккинга EF, нет необходимости сбрасывания ласт кэша при новом запросе)
- выделены отдельно сообщения. Категории:
   1. Сообщения-запросы - когда нужно отправить сообщение с ожиданием ответа от очереди
   2. Сообщения-ответы - ответ на сообщение-запрос
   3. Сообщение-событие - сообщение, которые не требует возвращаемого значения
- создан background service (со слоем application подсказало сердце)
